### PR TITLE
fix tinymce error switching  between HTML and VISUAL

### DIFF
--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -32,7 +32,7 @@ class SRI_Admin {
 	 */
 	function addMceValidElements( $init ) {
 		// Get the sizes
-		$sizes = sri_get_the_image_sizes();
+		$sizes = array_keys(sri_get_the_image_sizes());
 		
 		// If empty, stop now
 		if( empty( $sizes ) )


### PR DESCRIPTION
Hello, i like your plugin and i want make a little contribution fixing this little error

the problem appear always (all versión of wp over 3.3.1)

issue: it's unpossible to change between HTML and VISUAL editors

the problem trigger: addMceValidElements modify img values on extended_valid_elements for tinymce but it has an error

the cause: sri_get_the_image_sizes() without parametres of id on line 35 return an array with key/value then this array is merged on line 46 with array $basic_img but this array has only values. As result of this operation the variable $elements has some null values corresponding to image sizes. Finally when implode all the result for tinymece extended_valid_elements gets some similar to: ... img[|||||src|alt|title|height|width|class] ...

My Solution: on line 35 $sizes = array_keys(sri_get_the_image_sizes()); this gets just the values of the array and make the trick

i think thats all, thanks for your atention
